### PR TITLE
refactor: consolidate artifact downloads using merge_multiple

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,34 +19,14 @@ jobs:
     environment: pypi
 
     steps:
-    - name: Download x86_64 wheel artifacts
+    - name: Download all release artifacts
       uses: dawidd6/action-download-artifact@v12
       with:
         workflow: release.yml
-        name: wheels-x86_64
+        name: ^(wheels-.*|sdist)$
+        name_is_regexp: true
         path: dist/
-        search_artifacts: true
-        workflow_conclusion: success
-        commit: ${{ github.event.inputs.release_tag }}
-        if_no_artifact_found: fail
-
-    - name: Download aarch64 wheel artifacts
-      uses: dawidd6/action-download-artifact@v12
-      with:
-        workflow: release.yml
-        name: wheels-aarch64
-        path: dist/
-        search_artifacts: true
-        workflow_conclusion: success
-        commit: ${{ github.event.inputs.release_tag }}
-        if_no_artifact_found: fail
-
-    - name: Download sdist artifact
-      uses: dawidd6/action-download-artifact@v12
-      with:
-        workflow: release.yml
-        name: sdist
-        path: dist/
+        merge_multiple: true
         search_artifacts: true
         workflow_conclusion: success
         commit: ${{ github.event.inputs.release_tag }}


### PR DESCRIPTION
## Summary

- Use dawidd6/action-download-artifact's `merge_multiple` feature to download all release artifacts in a single step
- Replace 3 separate download steps with 1 using regex pattern `^(wheels-.*|sdist)$`

## Changes

Simplifies `publish.yml` from:
```yaml
- name: Download x86_64 wheel artifacts
  ...
- name: Download aarch64 wheel artifacts
  ...
- name: Download sdist artifact
  ...
```

To:
```yaml
- name: Download all release artifacts
  uses: dawidd6/action-download-artifact@v12
  with:
    name: ^(wheels-.*|sdist)$
    name_is_regexp: true
    merge_multiple: true
    ...
```

## Test plan

- [ ] Verify publish workflow still downloads all artifacts correctly