### PR TITLE
fix: add __version__ attribute to pychrony package

### DIFF
--- a/src/pychrony/__init__.py
+++ b/src/pychrony/__init__.py
@@ -51,6 +51,8 @@ For more information, see:
 - https://chrony-project.org/
 """
 
+from importlib.metadata import version, PackageNotFoundError
+
 from .models import (
     TrackingStatus,
     Source,
@@ -69,7 +71,14 @@ from .exceptions import (
 )
 from ._core._bindings import get_tracking, get_sources, get_source_stats, get_rtc_data
 
+try:
+    __version__ = version("pychrony")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"
+
 __all__ = [
+    # Version
+    "__version__",
     # Core functions
     "get_tracking",
     "get_sources",


### PR DESCRIPTION
## Summary
- Add `__version__` attribute to `pychrony` package using `importlib.metadata.version()`
- Include fallback to `"0.0.0.dev0"` for editable/development installs
- Export `__version__` in `__all__`

Fixes CI release workflow failure where the "Verify Test PyPI" step checks `pychrony.__version__` but the attribute didn't exist.

## Test plan
- [x] Unit tests pass (154 tests)
- [x] Lint, format, and type checks pass
- [x] Version accessible: `python -c "import pychrony; print(pychrony.__version__)"`
- [x] Package builds successfully with `uv build`