### PR TITLE
docs: add badges and improve installation clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # PyChrony: Python bindings for chrony NTP client
 
+[![PyPI version](https://img.shields.io/pypi/v/pychrony)](https://pypi.org/project/pychrony/)
+[![Python versions](https://img.shields.io/pypi/pyversions/pychrony)](https://pypi.org/project/pychrony/)
+[![CI](https://github.com/arunderwood/pychrony/actions/workflows/ci.yml/badge.svg)](https://github.com/arunderwood/pychrony/actions/workflows/ci.yml)
+[![License](https://img.shields.io/pypi/l/pychrony)](https://github.com/arunderwood/pychrony/blob/main/LICENSE)
+
 PyChrony provides Python bindings for [chrony](https://chrony.tuxfamily.org/) NTP client, allowing monitoring of chrony via native Python code.
 
 ## Features
@@ -12,13 +17,16 @@ PyChrony provides Python bindings for [chrony](https://chrony.tuxfamily.org/) NT
 
 ## Installation
 
-### Prerequisites
+```bash
+pip install pychrony
+```
 
-PyChrony uses [libchrony](https://gitlab.com/chrony/libchrony), a C library for communicating with chronyd.
+Pre-built wheels include libchrony—no system dependencies needed.
 
-**Pre-built wheels** (recommended): libchrony is bundled—no system dependencies needed.
+<details>
+<summary><strong>Building from Source</strong></summary>
 
-**Source installs** (sdist or development): Requires libchrony to be installed on your system. See below for installation instructions.
+Source installs (sdist or development) require [libchrony](https://gitlab.com/chrony/libchrony) to be installed on your system.
 
 #### libchrony Package Availability
 
@@ -26,13 +34,11 @@ PyChrony uses [libchrony](https://gitlab.com/chrony/libchrony), a C library for 
 |--------------|-----------|-----------------|
 | Fedora 42+ | ✅ Yes | `sudo dnf install libchrony-devel` |
 | RHEL/CentOS/Rocky/Alma 9 | ✅ Yes (EPEL) | `sudo dnf install epel-release && sudo dnf install libchrony-devel` |
-| Debian/Ubuntu | ❌ No | [Build from source](#building-libchrony-from-source) |
-| Alpine | ❌ No | [Build from source](#building-libchrony-from-source) |
-| Arch Linux | ❌ No | [Build from source](#building-libchrony-from-source) |
+| Debian/Ubuntu | ❌ No | Build from source (see below) |
+| Alpine | ❌ No | Build from source (see below) |
+| Arch Linux | ❌ No | Build from source (see below) |
 
 #### Building libchrony from Source
-
-For distributions that don't package libchrony, you'll need to build it from source:
 
 ```bash
 # Install build dependencies
@@ -53,13 +59,7 @@ sudo make install prefix=/usr
 sudo ldconfig
 ```
 
-### Install from PyPI
-
-```bash
-pip install pychrony
-```
-
-### Install from Source (Development)
+#### Development Install
 
 ```bash
 git clone https://github.com/arunderwood/pychrony.git
@@ -68,6 +68,8 @@ git submodule update --init
 uv sync --all-groups
 uv pip install -e .
 ```
+
+</details>
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Add 4 badges to README header: PyPI version, Python versions, CI status, License
- Restructure installation section to lead with `pip install pychrony`
- Collapse source/development instructions into a `<details>` section

Most users just need `pip install`—this makes that immediately clear while keeping build-from-source docs accessible.

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify badge links resolve to correct pages
- [ ] Verify collapsible section expands properly