### PR TITLE
ci(docs): serialize gh-pages deploys to avoid push races

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to `.github/workflows/docs.yml` so docs deploys run one at a time.
- `cancel-in-progress: false` so a queued tag-triggered deploy is never dropped.

## Why
[Run #25347980337](https://github.com/arunderwood/pychrony/actions/runs/25347980337) failed with `[rejected] gh-pages -> gh-pages (fetch first)`. PRs #93, #94, and #95 all merged within ~13 seconds; their three docs runs raced each other pushing to `gh-pages` and the middle one lost. The site itself is healthy (the last run won), but the next burst of rapid merges will hit the same race.

This is unrelated to yesterday's docs failure (#91), which was a `pymdown-extensions`/`pygments` template crash fixed in #92.

## Test plan
- [ ] Merge and confirm the `Documentation` workflow still runs on push to `main`.
- [ ] Next time multiple PRs merge close together, confirm the runs queue serially instead of failing.