### PR TITLE
feat(python): add Python 3.15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.12", "3.14"]
+        python: ["3.10", "3.12", "3.15"]
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
       - uses: actions/checkout@v7
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ docker build -t pychrony-test -f docker/Dockerfile.test .
 docker run --rm --cap-add=SYS_TIME pychrony-test sh -c "chronyd && sleep 2 && pytest tests/integration -v"
 ```
 
-Cross-version testing (Python 3.10-3.14) is handled by CI.
+Cross-version testing (Python 3.10-3.15) is handled by CI.
 
 ## Before Committing
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ with ChronyConnection() as conn:
 
 ## Compatibility
 
-- **Python**: 3.10, 3.11, 3.12, 3.13, 3.14
+- **Python**: 3.10, 3.11, 3.12, 3.13, 3.14, 3.15
 - **Platform**: Linux (primary), other platforms where libchrony is available
 - **chrony**: 4.x and later
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: System :: Networking :: Time Synchronization",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: POSIX :: Linux",
@@ -83,7 +84,7 @@ addopts = ["-v", "--tb=short"]
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp315-*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
Follow-on to #146. That PR bumped cibuildwheel to 4.2, which [builds CPython 3.15 wheels by default](https://cibuildwheel.pypa.io/en/stable/changelog/) off 3.15.0rc1 — ABI-compatible with the final release, so they're safe to publish. This PR makes the rest of the project agree.

## The actual publishing bug

The action bump on its own shipped nothing. `[tool.cibuildwheel] build` is an **explicit allowlist**, not a filter layered on top of cibuildwheel's defaults:

```toml
build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
```

Anything not enumerated is silently excluded, so "built by default" never reached the wheelhouse. Adding `cp315-*` is the change that actually publishes 3.15 artifacts.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | `Python :: 3.15` classifier; `cp315-*` added to the cibuildwheel allowlist |
| `ci.yml` | Matrix → 3.10–3.15 |
| `test.yml` | Matrix → 3.10–3.15 (had drifted to 3.10–3.13) |
| `release.yml` | Test PyPI verification → `["3.10", "3.12", "3.15"]` |
| `README.md`, `CLAUDE.md` | Compatibility docs |

`requires-python = ">=3.10"` needs no change — no upper bound.

## Verification

Not just config edits — the real artifact was built locally:

```
CIBW_BUILD="cp315-manylinux_aarch64" CIBW_ARCHS=aarch64 uvx "cibuildwheel>=4.2,<4.3" --platform linux
→ pychrony-…-cp315-cp315-manylinux_2_28_aarch64.whl
```

CFFI extension compiled against libchrony, and the wheel's own `test-command` passed 342 unit + contract tests inside the container on CPython 3.15. Also: full suite green on CPython 3.15 locally (347 passed), Docker integration suite against live chronyd (58 passed), and `ruff check` / `ruff format --check` / `ty check` clean.

`cffi` 2.1.1 already publishes cp315 wheels, so the dependency chain is ready.

## Notes

**Pyodide intentionally skipped.** cibuildwheel 4.2 also added `cp315-pyodide_wasm32`, but pychrony links libchrony and talks to a chronyd Unix socket — neither exists under WASM.

**Python 3.10 deliberately retained.** It's supported upstream until 2026-10-31, v1.0.0 only shipped in July, and Ubuntu 22.04 LTS ships 3.10 with support to April 2027 — a realistic target for an NTP-monitoring library. The cleaner move is one sweep in November, once 3.15 is GA (Oct 1) and 3.10 is EOL: drop 3.10, matrix to 3.11–3.15, ruff `target-version = "py311"`, and remove the `PYI034` ignore (3.11 has `typing.Self`, so `__enter__` can be annotated properly).

**Drift worth fixing separately.** `ci.yml` and `test.yml` substantially duplicate each other — the unit/contract suite and lint both run twice per push. That's precisely why `test.yml` sat two versions behind while `ci.yml` stayed green.