### PR TITLE
ci: gate docs build on PRs and before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,25 @@ jobs:
     - name: Run tests
       run: uv run pytest --cov=src --cov-report=xml
 
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install UV
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: uv sync --group docs
+
+    # docs.yml deploys straight to gh-pages on main, so this is the only
+    # chance to catch a broken docs build before it becomes a failed publish.
+    # --strict promotes broken links and mkdocstrings resolution failures
+    # (which would otherwise render an empty API page) into hard errors.
+    - name: Build documentation
+      run: uv run mkdocs build --strict
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,13 @@ jobs:
     - name: Install dependencies
       run: uv sync --group docs
 
+    # Gate the deploy on a strict build. `mike deploy` builds internally, but
+    # without --strict, so broken links or mkdocstrings resolution failures
+    # would publish a degraded site instead of failing. Runs before any git
+    # mutation so a bad build never touches gh-pages.
+    - name: Verify documentation builds
+      run: uv run mkdocs build --strict
+
     - name: Configure git
       run: |
         git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Problem

`docs.yml` only triggered on push to `main` and `v*` tags, and its only real step was `mike deploy --push`. Nothing built the docs on a pull request.

The practical effect: a dependency bump that broke the docs build would pass CI, merge, and then fail during publishing — the first time mkdocs ran was while writing to `gh-pages`. `ci.yml` installed the docs group via `uv sync --all-groups` but never invoked mkdocs.

This surfaced while reviewing #148 (pymdown-extensions 10.21.3 → 11.0.1, which carries a `BREAK` in the B64 extension). That bump turns out to be safe — `mkdocs.yml` declares no `markdown_extensions`, so B64 is never enabled — but nothing in CI would have told us either way.

## Changes

**`ci.yml`** — new `docs` job running `mkdocs build --strict` on PRs and pushes to main.

- Separate job rather than a step in the test matrix: the docs build is Python-version-independent, so running it 5× would be waste.
- Pinned to 3.12 to match the deploy job, so the check exercises the interpreter that actually publishes.
- Uses `uv sync --group docs` rather than `--all-groups`, mirroring `docs.yml`, so a bump that breaks publishing breaks this check.
- No submodule checkout and no libchrony needed — mkdocstrings resolves `pychrony.*` through griffe's static analysis rather than by importing.

**`docs.yml`** — the same strict build added before the deploy steps.

`mike deploy` does build internally, but without `--strict`, so a resolution failure would publish a degraded site (e.g. an API page with the `:::` directives silently dropped) instead of failing. Placed before `Configure git` so a bad build aborts while the job is still read-only. This also covers what the CI job cannot see: direct pushes to `main` and `v*` tag releases.

## Verification

- `mkdocs build --strict` passes on the current lockfile (pymdownx 10.21.3) and on #148's (11.0.1).
- Confirmed the built `api/index.html` renders fully (312KB) without libchrony present, so the no-submodule assumption holds.
- Both workflow files parse; step order in `docs.yml` is `checkout → Install UV → Install dependencies → Verify documentation builds → Configure git → Deploy main docs → Deploy versioned docs`.
- Full local suite green: 347 passed / 62 skipped, ruff check + format, ty, and Docker integration tests (58 passed / 7 skipped).

## Note on scope

`--strict` only fails on what mkdocs classes as an error. A purely visual regression — theme CSS, rendering changes — would still pass. This closes the build-breakage gap, not the appearance one.