### PR TITLE
chore(packaging): mark Development Status as Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     {name = "arunderwood", email = "arunderwood@users.noreply.github.com"}
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary

`pyproject.toml` still declared `"Development Status :: 3 - Alpha"`, left over from the original project scaffold (it traces back to `specs/001-python-scaffold/research.md`). The project tagged [v1.0.0](https://github.com/arunderwood/pychrony/releases/tag/v1.0.0) on 2026-07-12, with release notes stating "Things have been stable for a while and I've been using this lib without issue, cutting v1!" — so PyPI has been showing "alpha" for a library its maintainer has declared stable.

This bumps the classifier to `"Development Status :: 5 - Production/Stable"`. Chose 5 over the more conservative `4 - Beta` because the v1.0.0 release notes are an unambiguous stability declaration, and the semver major matches.

## Note on when this takes effect

**Classifiers are baked into published distributions, so this does not retroactively change the existing v1.0.0 listing on PyPI.** The v1.0.0 page will keep showing "Alpha" until a subsequent release is published from this metadata.

## Rest of the docs are already clean

Swept the packaging metadata and docs for other stale alpha/early/experimental framing:

- `README.md` — clean; describes the library in plain present tense with no stability caveats
- `docs/index.md` — clean
- `src/pychrony/__init__.py` docstring — clean
- No "subject to change" / "may change" / "pre-1.0" language anywhere in live files

The only remaining hits are in `specs/` (`001-python-scaffold`, `004-categorical-enums`), which CLAUDE.md and the ruff config both describe as frozen spec-kit design records that are intentionally not kept in sync with the code. Those statements were accurate when written, so I left them as historical record.

## Test plan

- `uv run pytest` — 347 passed, 62 skipped
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 59 files already formatted
- `uv run ty check src/` — passed
- Docker integration tests — 58 passed, 7 skipped