### PR TITLE
docs: prevent stale-image false pass in integration test command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,20 @@ uv pip install cibuildwheel               # install cibuildwheel for manylinux b
 cibuildwheel --platform linux             # build manylinux wheels (requires Docker)
                                           # output in wheelhouse/
 
-# Integration tests (require Docker with libchrony)
-docker build -t pychrony-test -f docker/Dockerfile.test .
-docker run --rm --cap-add=SYS_TIME pychrony-test sh -c "chronyd && sleep 2 && pytest tests/integration -v"
+# Integration tests (require Docker; image builds libchrony from vendor/)
+git submodule update --init --recursive   # vendor/libchrony must be populated
+docker build -t pychrony-test -f docker/Dockerfile.test . && \
+  docker run --rm --cap-add=SYS_TIME pychrony-test sh -c "chronyd && sleep 2 && pytest tests/integration -v"
 ```
+
+Keep the `&&` joining build and run. `pychrony-test` is a fixed tag, so if the
+build fails and `docker run` still executes, it silently reuses the last image
+under that tag — possibly built from a different worktree or an older commit —
+and reports a full pass. Confirm the pytest paths name the current worktree.
+
+Never pipe the build through `tail`/`head` to trim output: the pipeline then
+exits with the pager's status, which defeats the `&&` and reintroduces exactly
+that stale-image failure.
 
 Cross-version testing (Python 3.10-3.15) is handled by CI.
 
@@ -39,9 +49,12 @@ uv run pytest
 uv run ruff check .
 uv run ruff format .
 uv run ty check src/
-docker build -t pychrony-test -f docker/Dockerfile.test .
-docker run --rm --cap-add=SYS_TIME pychrony-test sh -c "chronyd && sleep 2 && pytest tests/integration -v"
+docker build -t pychrony-test -f docker/Dockerfile.test . && \
+  docker run --rm --cap-add=SYS_TIME pychrony-test sh -c "chronyd && sleep 2 && pytest tests/integration -v"
 ```
+
+A green integration run only counts if the build ahead of it succeeded — see the
+stale-image note above.
 
 ## Architecture
 


### PR DESCRIPTION
## Problem

The integration-test commands in `CLAUDE.md` listed build and run on separate lines:

```bash
docker build -t pychrony-test -f docker/Dockerfile.test .
docker run --rm --cap-add=SYS_TIME pychrony-test sh -c "chronyd && sleep 2 && pytest tests/integration -v"
```

Run as a block, the second line executes regardless of whether the build succeeded. Because `pychrony-test` is a fixed tag, the run then silently reuses whatever image was last tagged — possibly built from a different worktree or an older commit — and reports a full pass.

This is not hypothetical. It produced **58 green integration tests against an image from an unrelated worktree**, while the build had actually failed (`vendor/libchrony` was empty — the submodule had never been initialized). It was caught only because the pytest output showed paths under a different worktree name than the one being tested.

The failure mode is quiet in the worst way: a stale image is usually *similar* to the current tree, so the results look plausible.

## Changes

- Join build and run with `&&` in both command blocks, so a failed build stops the run.
- Document the `git submodule update --init --recursive` prerequisite — the missing submodule is what caused the build failure that exposed this.
- Warn against piping the build through `tail`/`head` to trim its output. `docker build ... | tail -5 && docker run ...` makes the pipeline exit with the *pager's* status, which defeats the `&&` and reintroduces the identical failure.
- Add a pointer from the "Before Committing" block noting a green run only counts if the build ahead of it succeeded.

## Verification

Ran the documented command verbatim in both directions:

- **Failure path**: build against a nonexistent Dockerfile short-circuits with rc=1; `docker run` never executes.
- **Success path**: fresh build, then 58 passed / 7 skipped with pytest paths naming the current worktree.

## Note

Docs-only; no code or workflow changes. Separate from #150 (which gates the *docs* build in CI) so each stays single-purpose and mergeable on its own.